### PR TITLE
refactor: rename arangoStore package to arangostore

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ import (
 
 	"github.com/go-oauth2/oauth2/v4/manage"
 
-	arangoStore "github.com/gabor-boros/go-oauth2-arangodb"
+	arangostore "github.com/gabor-boros/go-oauth2-arangodb"
 )
 
 func main() {
@@ -49,21 +49,21 @@ func main() {
 	})
 
 	db, _ := client.Database(context.Background(), os.Getenv("ARANGO_DB"))
-	
-	clientStore, _ := arangoStore.NewClientStore(
-		arangoStore.WithClientStoreDatabase(db),
-		arangoStore.WithClientStoreCollection("oauth2_clients"),
+
+	clientStore, _ := arangostore.NewClientStore(
+		arangostore.WithClientStoreDatabase(db),
+		arangostore.WithClientStoreCollection("oauth2_clients"),
 	)
 
-	tokenStore, _ := arangoStore.NewTokenStore(
-		arangoStore.WithTokenStoreDatabase(db),
-		arangoStore.WithTokenStoreCollection("oauth2_tokens"),
+	tokenStore, _ := arangostore.NewTokenStore(
+		arangostore.WithTokenStoreDatabase(db),
+		arangostore.WithTokenStoreCollection("oauth2_tokens"),
 	)
 
 	manager := manage.NewDefaultManager()
 	manager.MapTokenStorage(tokenStore)
 	manager.MapClientStorage(clientStore)
-	
+
 	// ...
 }
 ```

--- a/arangodb.go
+++ b/arangodb.go
@@ -1,4 +1,4 @@
-package arangoStore
+package arangostore
 
 import "fmt"
 

--- a/arangodb_test.go
+++ b/arangodb_test.go
@@ -1,4 +1,4 @@
-package arangoStore
+package arangostore
 
 import (
 	"context"

--- a/client_store.go
+++ b/client_store.go
@@ -1,4 +1,4 @@
-package arangoStore
+package arangostore
 
 import (
 	"context"

--- a/client_store_test.go
+++ b/client_store_test.go
@@ -1,4 +1,4 @@
-package arangoStore
+package arangostore
 
 import (
 	"context"

--- a/token_store.go
+++ b/token_store.go
@@ -1,4 +1,4 @@
-package arangoStore
+package arangostore
 
 import (
 	"context"

--- a/token_store_test.go
+++ b/token_store_test.go
@@ -1,4 +1,4 @@
-package arangoStore
+package arangostore
 
 import (
 	"context"


### PR DESCRIPTION
This PR renames the `arangoStore` package to `arangostore` to keep conventions.